### PR TITLE
SDS-723 change user group import order

### DIFF
--- a/src/Resources/config/fixtures_jobs.yml
+++ b/src/Resources/config/fixtures_jobs.yml
@@ -36,7 +36,7 @@ jobs:
             filePath: init.xlsx
 
     fixtures_user_group_csv:
-        order: 30
+        order: 15
         connector: Data fixtures
         alias:     fixtures_user_group_csv
         label:     User groups data fixtures


### PR DESCRIPTION
SDS-723: change user group import order for EE-1.6.
Group must be create before import init.xlsx
fix issue: Errors with init bundle & akeneo 1.6 EE #5 
