### PR TITLE
Fix import family requirements

### DIFF
--- a/src/Iterator/InitFamilyFileIterator.php
+++ b/src/Iterator/InitFamilyFileIterator.php
@@ -90,8 +90,6 @@ class InitFamilyFileIterator extends InitFileIterator
             }
         }
 
-        $data['attributes'] = implode(',', $data['attributes']);
-
         return $data;
     }
 

--- a/src/Resources/config/array_converters.yml
+++ b/src/Resources/config/array_converters.yml
@@ -5,3 +5,10 @@ services:
     pim_excel_installer.array_converter.flat_to_standard.attribute:
         class: '%pim_excel_installer.array_converter.flat_to_standard.attribute.class%'
         parent: 'pim_connector.array_converter.flat_to_standard.attribute'
+
+    pim_excel_installer.array_converter.flat_to_standard.family:
+        class: '%pim_connector.array_converter.dummy.class%'
+        arguments:
+            - '@pim_connector.array_convertor.checker.fields_requirement'
+            - ['code']
+            - ['code']

--- a/src/Resources/config/readers.yml
+++ b/src/Resources/config/readers.yml
@@ -92,7 +92,7 @@ services:
         class: '%pim_connector.reader.file.xlsx.class%'
         arguments:
             - '@pim_excel_installer.reader.file.xlsx_family_iterator_factory'
-            - '@pim_connector.array_converter.flat_to_standard.family'
+            - '@pim_excel_installer.array_converter.flat_to_standard.family'
             - family_data_row:    2
               family_code_column: 1
               family_labels_locales_row: 1
@@ -101,4 +101,3 @@ services:
               attribute_label_row: 5
               attribute_data_row: 6
               include_worksheets: [ '/^family/' ]
-


### PR DESCRIPTION
A PR based on the work of @maximequeneau in #7 .

The only difference is that i do not use directly the dummy converter, but a dedicated one that at least check for `code` field presence.
