### PR TITLE
Return null on blank lines

### DIFF
--- a/src/Iterator/InitFamilyFileIterator.php
+++ b/src/Iterator/InitFamilyFileIterator.php
@@ -73,6 +73,9 @@ class InitFamilyFileIterator extends InitFileIterator
             }
 
             if ($index >= (int) $this->options['attribute_data_row']) {
+                if (count($row) === 0) {
+                    continue;
+                }
                 $code = $row[$codeColumn];
                 if ($code === '') {
                     continue;

--- a/src/Iterator/InitFileIterator.php
+++ b/src/Iterator/InitFileIterator.php
@@ -50,6 +50,9 @@ class InitFileIterator extends FileIterator
         }
 
         $data = $this->trimRight($data);
+        if (count($data) ===0) {
+            return null;
+        }
 
         return $data;
     }


### PR DESCRIPTION
When modifying xlsx files with libreoffice, or simply when a row is just made of blank spaces, we must consider the row as blank.