### PR TITLE
Fixes missing job instances when initializing Akeneo 2.3 with ExcelInitBundle Fixtures.

### DIFF
--- a/src/Resources/fixtures/minimal_EE/jobs.yml
+++ b/src/Resources/fixtures/minimal_EE/jobs.yml
@@ -14,6 +14,36 @@ jobs:
         alias:     remove_product_value
         label:     Mass remove products values
         type:      mass_edit
+    move_to_category:
+        connector: Akeneo Mass Edit Connector
+        alias:     move_to_category
+        label:     Mass move to categories
+        type:      mass_edit
+    add_to_group:
+        connector: Akeneo Mass Edit Connector
+        alias:     add_to_group
+        label:     Mass add product to group
+        type:      mass_edit
+    add_association:
+        connector: Akeneo Mass Edit Connector
+        alias:     add_association
+        label:     Mass associate products
+        type:      mass_edit
+    add_to_category:
+        connector: Akeneo Mass Edit Connector
+        alias:     add_to_category
+        label:     Mass add to categories
+        type:      mass_edit
+    remove_from_category:
+        connector: Akeneo Mass Edit Connector
+        alias:     remove_from_category
+        label:     Mass remove from categories
+        type:      mass_edit
+    delete_products_and_product_models:
+        connector: Akeneo Mass Edit Connector
+        alias:     delete_products_and_product_models
+        label:     Mass delete products
+        type:      mass_delete
     publish_product:
         connector: Akeneo Mass Edit Connector
         alias:     publish_product
@@ -27,12 +57,27 @@ jobs:
     edit_common_attributes:
         connector: Akeneo Mass Edit Connector
         alias:     edit_common_attributes
-        label:     Mass edit common product attributes
+        label:     Mass edit product attributes
+        type:      mass_edit
+    add_attribute_value:
+        connector: Akeneo Mass Edit Connector
+        alias:     add_attribute_value
+        label:     Mass add attribute value
+        type:      mass_edit
+    add_to_existing_product_model:
+        connector: Akeneo Mass Edit Connector
+        alias:     add_to_existing_product_model
+        label:     Add to existing product model
         type:      mass_edit
     set_attribute_requirements:
         connector: Akeneo Mass Edit Connector
         alias:     set_attribute_requirements
         label:     Set family attribute requirements
+        type:      mass_edit
+    change_parent_product:
+        connector: Akeneo Mass Edit Connector
+        alias:     change_parent_product
+        label:     Change parent product model
         type:      mass_edit
     csv_product_quick_export:
         connector: Akeneo CSV Connector
@@ -94,6 +139,11 @@ jobs:
         connector: Akeneo Product Asset Connector
         alias:     apply_assets_mass_upload
         label:     Process mass uploaded assets
+        type:      mass_upload
+    apply_assets_mass_upload_into_asset_collection:
+        connector: Akeneo Product Asset Connector
+        alias:     apply_assets_mass_upload_into_asset_collection
+        label:     Process mass uploaded assets and add to product
         type:      mass_upload
     xlsx_product_quick_export:
         connector: Akeneo XLSX Connector


### PR DESCRIPTION
I have took the content of the job file of the EE version; the missing job instances prevent things like mass delete of products from working. 

Regards